### PR TITLE
Fixed parent namespace

### DIFF
--- a/Providers/MainServiceProvider.php
+++ b/Providers/MainServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Containers\Vendor\Settings\Providers;
 
-use App\Ship\Parents\Providers\MainProvider;
+use App\Ship\Parents\Providers\MainServiceProvider as MainProvider;
 
 /**
  * Class MainServiceProvider.


### PR DESCRIPTION
There is no file with the name `MainProvider` in namespace `App\Ship\Parents\Providers\MainProvider` in Apiato v11.x and it causes an error during package installation.

This is the parent class name in apiato v11.x:
 [https://github.com/apiato/apiato/blob/11.x/app/Ship/Parents/Providers/MainServiceProvider.php](https://github.com/apiato/apiato/blob/11.x/app/Ship/Parents/Providers/MainServiceProvider.php)